### PR TITLE
fix: translate section about Slavoj Zizek

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
 		<br>
 
 		<div id="wisdom">
-			<p>Slavoj Zizek mentions something interesting about wisdom and proverbs:</p>
+			<p>O filósofo Slavoj Zizek tem umas ideias interessantes sobre provérbios e sabedoria convencional:</p>
 			<p><i>Whatever I say, you can sell it as wisdom.</i></p>
 
 			<iframe width="560" height="315" src="https://www.youtube.com/embed/tKoGQpEkpO0?start=12" title="YouTube video player"


### PR DESCRIPTION
the page is portuguese, so all text should be, except the quote